### PR TITLE
feat: add support for graphql files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovrsea/graphql-detect-unused-operations",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1350,24 +1350,23 @@
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.6.tgz",
-      "integrity": "sha512-24F+gPOMsezus2hhzJ3GXhpSQarMdTZAeTSkXgDTOH+VAPlIHvC7zMNuZ3Jt+3FsSXBF5NV4g0GmuSP+/3W9hg==",
-      "dev": true,
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.16.tgz",
+      "integrity": "sha512-lK1N3Y2I634FS12nd4bu7oAJbai3bUc28yeX+boT+C83KTO4ujGHm+6hPC8X/FRGwhKOnZBxUM7I5nvb3HiUxw==",
       "requires": {
-        "@graphql-tools/import": "6.7.7",
-        "@graphql-tools/utils": "8.13.0",
+        "@graphql-tools/import": "6.7.17",
+        "@graphql-tools/utils": "9.2.1",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.0.tgz",
-          "integrity": "sha512-cI4LdXElgVK2jFoq0DpANlvk4Di6kIapHsJI63RCepQ6xZe+mLI1mDrGdesG37s2BaABqV3RdTzeO/sPnTtyxQ==",
-          "dev": true,
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
           "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
             "tslib": "^2.4.0"
           }
         }
@@ -1386,22 +1385,21 @@
       }
     },
     "@graphql-tools/import": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.7.tgz",
-      "integrity": "sha512-EPMge+w+2bsLxIvTLSHCe2KSMXUPSp8tPyJdWNHINMJyb66iHWAgPcYEr+FdGYtYU00bL/KGxr2Zsy3IZz+5Xw==",
-      "dev": true,
+      "version": "6.7.17",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.17.tgz",
+      "integrity": "sha512-bn9SgrECXq3WIasgNP7ful/uON51wBajPXtxdY+z/ce7jLWaFE6lzwTDB/GAgiZ+jo7nb0ravlxteSAz2qZmuA==",
       "requires": {
-        "@graphql-tools/utils": "8.13.0",
+        "@graphql-tools/utils": "9.2.1",
         "resolve-from": "5.0.0",
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.0.tgz",
-          "integrity": "sha512-cI4LdXElgVK2jFoq0DpANlvk4Di6kIapHsJI63RCepQ6xZe+mLI1mDrGdesG37s2BaABqV3RdTzeO/sPnTtyxQ==",
-          "dev": true,
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
           "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
             "tslib": "^2.4.0"
           }
         }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/code-file-loader": "7.3.6",
+    "@graphql-tools/graphql-file-loader": "^7.5.16",
     "@graphql-tools/load": "7.7.7",
     "@graphql-tools/utils": "8.12.0",
     "@swc/core": "^1.3.11",

--- a/src/detectUnusedOperations.ts
+++ b/src/detectUnusedOperations.ts
@@ -5,6 +5,7 @@ import * as glob from "glob";
 import { loadDocuments } from "@graphql-tools/load";
 import { Source } from "@graphql-tools/utils";
 import { CodeFileLoader } from "@graphql-tools/code-file-loader";
+import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader"
 import { DocumentNode } from "graphql";
 import { parseDocumentNode } from "./findInDocumentNode";
 import { parseSchema } from "./parseSchema";
@@ -94,7 +95,7 @@ const loadAndParseFile =
 
     try {
       const sources = await loadDocuments(file, {
-        loaders: [new CodeFileLoader()],
+        loaders: [new CodeFileLoader(), new GraphQLFileLoader()],
       });
 
       const ret = sources


### PR DESCRIPTION
Currently operations can only be loaded from Typescript or Javascript files. 

This pull requests enables usage of graphql files in the glob pattern.